### PR TITLE
Add username and password to check_clickhouse

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Arnoways @B-Marine @jriouovh @koleo @wilfriedroset
+* @B-Marine @jriouovh @koleo @wilfriedroset

--- a/bin/check_clickhouse
+++ b/bin/check_clickhouse
@@ -5,6 +5,7 @@ import time
 
 import nagiosplugin
 import nagiosplugin.state
+import yaml
 
 try:
     from clickhouse_driver import Client
@@ -90,10 +91,17 @@ class ExtendedSummary(nagiosplugin.Summary):
 class Clickhouse(nagiosplugin.Resource):
     """Nagios resource used to gather metrics from ClickHouse instance"""
 
-    def __init__(self, command, host, port, secure):
+    # default password is ''
+    # https://clickhouse-driver.readthedocs.io/en/latest/api.html#connection
+
+    def __init__(self, command, host, port, secure, user="default", password=""):
         self.command = command
         self.secure = secure
-        self.client = Client(host=host, port=port, secure=secure)
+        self.user = user
+        self.password = password
+        self.client = Client(
+            host=host, port=port, secure=secure, user=user, password=password
+        )
 
     def query(self, query, default=None):
         """Query and return one value or the default value"""
@@ -129,7 +137,13 @@ class Clickhouse(nagiosplugin.Resource):
         for host, port in members:
             value = f"{host}:{port}"
             try:
-                client = Client(host=host, port=port, secure=self.secure)
+                client = Client(
+                    host=host,
+                    port=port,
+                    secure=self.secure,
+                    user=self.user,
+                    password=self.password,
+                )
                 client.execute("select 1")
                 result = True
             except Exception as err:
@@ -236,6 +250,12 @@ def parse_args():
         dest="secure",
         action="store_true",
         help="Enable TLS when connecting to the ClickHouse instance",
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        dest="config",
+        help="Path to a clickhouse-client config file",
     )
 
     subparsers = parser.add_subparsers(dest="command")
@@ -351,6 +371,11 @@ def parse_args():
     return parser.parse_args()
 
 
+def read_config(config_file):
+    with open(config_file, "r") as conf:
+        return yaml.safe_load(conf)
+
+
 @nagiosplugin.guarded
 def main():
     if not HAS_CLICKHOUSE_DRIVER:
@@ -388,12 +413,16 @@ def main():
         port = CH_PORT
         if args.secure:
             port = CH_PORT_TLS
-
+    config = {}
+    if args.config:
+        config = read_config(args.config)
     resource = Clickhouse(
         command=args.command,
         host=args.host,
         port=port,
         secure=args.secure,
+        user=config.get("user", "default"),
+        password=config.get("password", ""),
     )
 
     summary = ExtendedSummary()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
+clickhouse-driver==0.2.9
 dnspython==2.6.1
 nagiosplugin==1.3.3
 psutil==6.0.0
 psycopg2-binary==2.9.9
 pymongo==4.8.0
+pytz==2024.2
+PyYAML==6.0.2
+tzlocal==5.2


### PR DESCRIPTION
The best practice is to use a custom username/password instead of relying on the default one. This pull request add this support, thanks to [Arnoways](https://github.com/ovh/ovh-nagios-plugins/commits?author=Arnoways).

This pull request also removes Arnoways from the code owners because he doesn't have write permissions on the repository anymore. But your contributions are welcomed of course!