### PR TITLE
fix(check_clickhouse): Extended summary

### DIFF
--- a/bin/check_clickhouse
+++ b/bin/check_clickhouse
@@ -81,8 +81,20 @@ class InvertedScalarContext(nagiosplugin.ScalarContext):
 class ExtendedSummary(nagiosplugin.Summary):
     """Display results with more information than the default Summary"""
 
+    def __init__(self, expected: bool = True):
+        self.expected = expected
+
     def problem(self, results):
-        return ", ".join(sorted(str(r) for r in results if not r.metric.value))
+        return ", ".join(
+            sorted(
+                str(r)
+                for r in results
+                if not isinstance(r.metric.value, bool)
+                or (
+                    isinstance(r.metric.value, bool) and r.metric.value != self.expected
+                )
+            )
+        )
 
     def ok(self, results):
         return ", ".join(sorted(str(r) for r in results))


### PR DESCRIPTION
The extended summary was removing crucial information when something was wrong.

```
./check_clickhouse detached_parts
CLICKHOUSE CRITICAL | 'detached parts'=100000;~:0;1000
```

Only "CRITICAL" is shown, nothing else.

This commit fixes this behavior:

```
CLICKHOUSE CRITICAL - detached parts is 100000 (outside range 0:1000) | 'detached parts'=100000;~:0;1000
```