### PR TITLE
fix(check_clickhouse): Set minimum pending file rate to 0

### DIFF
--- a/bin/check_clickhouse
+++ b/bin/check_clickhouse
@@ -202,7 +202,9 @@ class Clickhouse(nagiosplugin.Resource):
         after = self.query(query)
         return [
             nagiosplugin.Metric(
-                "pending files rate", after - before, context="pending_files_rate"
+                "pending files rate",
+                max(after - before, 0),
+                context="pending_files_rate",
             )
         ]
 


### PR DESCRIPTION
From time to time, we have a pending file rate of -1 which is outside of the expected range (0:300). It's unexpected to see an increasing rate. It ok to have a reducing rate.