### PR TITLE
fix(check_timescaledb): job_errors thresholds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,24 +1,22 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict
       - id: end-of-file-fixer
-      - id: fix-encoding-pragma
-        args: ['--remove']
       - id: requirements-txt-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 26.1.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 7.1.0
+    rev: 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 7.0.0
     hooks:
       - id: isort

--- a/bin/check_mongodb
+++ b/bin/check_mongodb
@@ -109,9 +109,9 @@ class Mongodb(nagiosplugin.Resource):
         if self.tls:
             connection_args["tls"] = self.tls
         if self.tls_allow_invalid_certificates:
-            connection_args[
-                "tlsAllowInvalidCertificates"
-            ] = self.tls_allow_invalid_certificates
+            connection_args["tlsAllowInvalidCertificates"] = (
+                self.tls_allow_invalid_certificates
+            )
         self.db = pymongo.MongoClient(self.host, **connection_args)
 
     def check_connections(self):
@@ -409,9 +409,9 @@ def main():
     if args.tls:
         arguments["tls"] = args.tls
     if args.tls_allow_invalid_certificates:
-        arguments[
-            "tls_allow_invalid_certificates"
-        ] = args.tls_allow_invalid_certificates
+        arguments["tls_allow_invalid_certificates"] = (
+            args.tls_allow_invalid_certificates
+        )
 
     if args.command in ["canary_read", "canary_write"]:
         arguments["canary_database"] = args.canary_database

--- a/bin/check_timescaledb
+++ b/bin/check_timescaledb
@@ -44,6 +44,27 @@ class BooleanContext(nagiosplugin.Context):
         return self.result_cls(state, metric.name, metric)
 
 
+class ThresholdContext(nagiosplugin.Context):
+    """Trigger alerts when value reaches or exceeds thresholds"""
+
+    def __init__(self, name, warning, critical):
+        super().__init__(name)
+        self.warning = warning
+        self.critical = critical
+
+    def evaluate(self, metric, resource):
+        if metric.value >= self.critical:
+            state = nagiosplugin.state.Critical
+        elif metric.value >= self.warning:
+            state = nagiosplugin.state.Warn
+        else:
+            state = nagiosplugin.state.Ok
+        return self.result_cls(state, metric.name, metric)
+
+    def performance(self, metric, resource):
+        return f"{metric.name}={metric.value};{self.warning};{self.critical}"
+
+
 class Timescaledb(nagiosplugin.Resource):
     """Nagios resource used to gather metrics from PostgreSQL instance"""
 
@@ -359,7 +380,7 @@ def main():
     if args.command == "version":
         context = BooleanContext("version", level=args.level)
     elif args.command == "job_errors":
-        context = nagiosplugin.ScalarContext("job_errors", args.warning, args.critical)
+        context = ThresholdContext("job_errors", args.warning, args.critical)
     elif args.command == "background_workers":
         if not HAS_PSUTIL:
             raise nagiosplugin.CheckError("psutil is required")


### PR DESCRIPTION
Default warning/critical thresholds set to 1 on `check_timescaledb job_errors` will alert when 2 errors or more are detected. We want to trigger a warn/crit at the first error.

Setting defaults to 0 instead of 1 does not help, so implementing a custom context (ThresholdContext) to use "greater or equal" comparison.